### PR TITLE
Add --version flag to CLI

### DIFF
--- a/cmd/sweep/main.go
+++ b/cmd/sweep/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"runtime" // <-- added for printing OS/Arch
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -17,8 +18,16 @@ import (
 	"github.com/tanmayshahane/kyubisweep/pkg/scanner"
 )
 
-// Version of KyubiSweep
-var Version = "v0.1.0"
+// Version of KyubiSweep (set at build time using -ldflags)
+var Version = "dev"
+// init updates Version automatically for go run using environment variable
+func init() {
+	if Version == "dev" {
+		if v := os.Getenv("VERSION"); v != "" {
+			Version = v
+		}
+	}
+}
 
 
 const (
@@ -48,15 +57,15 @@ func main() {
 	quiet := flag.Bool("quiet", false, "Minimal output, just summary stats")
 	moveTo := flag.String("move-to", "", "Quarantine: Move files with secrets to this directory")
 
-	// ---- NEW VERSION FLAG ----
-	versionFlag := flag.Bool("version", false, "Print version and exit")
+	// ---- VERSION FLAG ----
+	versionLong := flag.Bool("version", false, "Print version and exit")
+	versionShort := flag.Bool("v", false, "Print version and exit (shorthand)")
 	
-
 	flag.Parse()
 
 	// Check version flag first
-	if *versionFlag {
-		fmt.Println("KyubiSweep", Version)
+	if *versionLong || *versionShort {
+		fmt.Printf("KyubiSweep %s (%s/%s)\n", Version, runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 
@@ -187,6 +196,10 @@ func printHelp() {
 	fmt.Println("  kyubisweep --path . --all")
 	fmt.Println("  kyubisweep --path . --move-to ./secure_vault")
 	fmt.Println("  kyubisweep --path . --json")
+
+	fmt.Println("  --version, -v           Print version and exit") // <-- new line
+
+
 	fmt.Println("")
 }
 

--- a/cmd/sweep/main.go
+++ b/cmd/sweep/main.go
@@ -17,6 +17,10 @@ import (
 	"github.com/tanmayshahane/kyubisweep/pkg/scanner"
 )
 
+// Version of KyubiSweep
+var Version = "v0.1.0"
+
+
 const (
 	numWorkers = 10
 
@@ -44,7 +48,17 @@ func main() {
 	quiet := flag.Bool("quiet", false, "Minimal output, just summary stats")
 	moveTo := flag.String("move-to", "", "Quarantine: Move files with secrets to this directory")
 
+	// ---- NEW VERSION FLAG ----
+	versionFlag := flag.Bool("version", false, "Print version and exit")
+	
+
 	flag.Parse()
+
+	// Check version flag first
+	if *versionFlag {
+		fmt.Println("KyubiSweep", Version)
+		os.Exit(0)
+	}
 
 	if *showHelp {
 		printHelp()


### PR DESCRIPTION
### Summary
Added a --version (-v) flag to KyubiSweep CLI to display the current version and OS/Arch.

### Changes
- Introduced Version variable:
- Default: dev
- Can be set via VERSION environment variable (go run) or build-time -ldflags (go build).
- Updated help output to include --version/-v.

### Testing
**1. go run with env variable:**

- $env:VERSION = (Get-Date -Format "yyyyMMdd.HHmm")
- go run cmd/sweep/main.go -v

**2. go build with -ldflags:**

- $buildNumber = Get-Date -Format "yyyyMMdd.HHmm"
- go build -ldflags "-X main.Version=$buildNumber" -o kyubisweep.exe cmd/sweep/main.go
- .\kyubisweep.exe -v


Both methods print the correct version and exit without scanning.